### PR TITLE
fix Firefox ignoring target margins

### DIFF
--- a/zoomerang.js
+++ b/zoomerang.js
@@ -1,3 +1,7 @@
+/*
+ * zoomerang.js - http://yyx990803.github.io/zoomerang/
+ */
+
 (function () {
 
     // elements
@@ -103,9 +107,10 @@
     }
 
     var stylesToCopy = [
-        'position', 'display', 'float', 'margin',
+        'position', 'display', 'float',
         'top', 'left', 'right', 'bottom',
-        'font', 'lineHeight', 'verticalAlign'
+        'marginBottom', 'marginLeft', 'marginRight',
+        'marginTop', 'font', 'lineHeight', 'verticalAlign'
     ]
 
     function copy (el, box) {
@@ -135,6 +140,7 @@
     var api = {
 
         config: function (opts) {
+
             if (!opts) return options
             for (var key in opts) {
                 options[key] = opts[key]
@@ -220,7 +226,7 @@
             setStyle(target, {
                 transform: 'translate(' + dx + 'px, ' + dy + 'px)'
             })
-            
+
             target.addEventListener(transEndEvent, onEnd)
             function onEnd () {
                 target.removeEventListener(transEndEvent, onEnd)
@@ -260,7 +266,6 @@
             
             return this
         }
-
     }
 
     overlay.addEventListener('click', api.close)


### PR DESCRIPTION
Thank you so much for creating the zoomerang - I used it on my website: http://www.tknomad.com :+1: 

So, it turns out my Firefox (version 25.0) was reporting 'marginLeft' computed style, etc. but not 'margin'.  Chrome reports 'margin-left', etc. format, but FF does not.

Just give your test image margins and test in Firefox to see the bug - image transforms to wrong position on close() and then jumps to correct original position on end of transform.

Some dev screenshots:

![margin-ff-undefined](https://f.cloud.github.com/assets/451178/1722207/56d43e4a-623c-11e3-8a59-bc0a66f52b0a.png)
![margins-ff-undefined](https://f.cloud.github.com/assets/451178/1722209/5e770f1a-623c-11e3-97ff-02cb7932795c.png)
![margins-chrome](https://f.cloud.github.com/assets/451178/1722212/6dc6c104-623c-11e3-8d2d-5551b4abf5a7.png)

I read this doc:

http://javascript.info/tutorial/styles-and-classes-getcomputedstyle#style

And camel casing seems to do the trick.

Tested on:
- Firefox 25.0
- Chrome Canary 33.0.1734.5
- Chrome Beta 32.0.1700.41
- Safari 7.0 (9537.71)
- Opera Next 19.0.1326.9

And all is fine!

Next up, I'm getting funky effects on my Android Browser.  I might be troubleshooting that next.
