### PR TITLE
fixed transitionend not firing on older webkit-based browsers

### DIFF
--- a/zoomerang.js
+++ b/zoomerang.js
@@ -78,8 +78,8 @@
             tform = ['transform', 'webkitTransform', 'mozTransform'],
             end   = {
                 'transition'       : 'transitionend',
-                'MozTransition'    : 'transitionend',
-                'WebkitTransition' : 'webkitTransitionEnd'
+                'mozTransition'    : 'transitionend',
+                'webkitTransition' : 'webkitTransitionEnd'
             }
         trans.some(function (prop) {
             if (overlay.style[prop] !== undefined) {


### PR DESCRIPTION
So, I fixed a problem on the iPad and Android, where I could only do one zoom in/out cycle.  Turns out onEnd() event wasn't firing:

![ios-safari-transition-undefined](https://f.cloud.github.com/assets/451178/1726869/5a75ff52-6296-11e3-9751-a7590bdab432.png)

I made the placeholder visible and you can see the target floating after close()

![ios-safari-transitionend-not-fired](https://f.cloud.github.com/assets/451178/1726870/5a7891cc-6296-11e3-8114-b9fe77d7f135.png)

I hope I got the 'mozTransitionEnd' right.  I found some apparently conflicting sources on that.  According to:

http://blogs.msdn.com/b/eternalcoding/archive/2011/11/01/css3-transitions.aspx

The events are:

```
Chrome & Safari: webkitTransitionEnd
Firefox: mozTransitionEnd
Opera: oTransitionEnd
Internet Explorer: MSTransitionEnd
```

On the other hand, this lib suggests 'transitionend':

https://github.com/EvandroLG/transitionEnd/blob/master/src/transition-end.js

I found this jsfiddle too:

http://jsfiddle.net/ginpei/fMUtz/

My Android 2.3.6 is still showing a separate glitch with the target size shrinking after the scale animation, like in this video:

http://www.youtube.com/watch?v=Aplk-m8WRUE

Apparently it's a "known bug".  I'm wondering whether a workaround will turn out to be possible.
