### PR TITLE
fix for android 4.1 browser

### DIFF
--- a/zoomerang.js
+++ b/zoomerang.js
@@ -74,8 +74,8 @@
 
     function sniffTransition () {
         var ret   = {},
-            trans = ['transition', 'webkitTransition', 'mozTransition'],
-            tform = ['transform', 'webkitTransform', 'mozTransform'],
+            trans = ['webkitTransition', 'transition', 'mozTransition'],
+            tform = ['webkitTransform', 'transform', 'mozTransform'],
             end   = {
                 'transition'       : 'transitionend',
                 'mozTransition'    : 'transitionend',


### PR DESCRIPTION
Hi,

Apparently, android 4.1 is weird in the way it defines the transition property : both transition and webkitTransition are defined, but only webkitTransitionEnd actually works. (See http://stackoverflow.com/questions/13823188/android-4-1-change-transition-and-webkittransition-defiend-how-to-properly-de)

By checking the webkit- prefix first, I managed to overcome this issue (at least on android 4.1).

Cheers
