### PR TITLE
Adding the missing comma and removing trailing spaces. 

### DIFF
--- a/zoomerang.js
+++ b/zoomerang.js
@@ -92,7 +92,7 @@
             if (overlay.style[prop] !== undefined) {
                 ret.transform = prop
                 return true
-            }  
+            }
         })
         return ret
     }
@@ -263,7 +263,7 @@
                     api.open(el)
                 }
             })
-            
+
             return this
         }
     }
@@ -278,4 +278,4 @@
     } else {
         this.Zoomerang = api
     }
-})()
+})();


### PR DESCRIPTION
- When one uses, zoomerang in SPA(single page applicaitons) like
  angularjs with yeoman. The build tool will just joins the files
  without the `;` which leads to a script error later.
- Removed trailing spaces.
