### PR TITLE
Add 2 onBefore events

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This is largely inspired by [Medium](http://medium.com)'s avatar zoom in effect,
     - `deepCopy` - whether to copy innerHTML. If target element has complicated inner structure you might need this to make it work. default: `false`
     - `onOpen` - a callback function that will be called when a target is zoomed in and transition has ended. It will get the target element as the argument.
     - `onClose` - same as `onOpen`, except fired when zoomed out.
-
+    - `onBeforeOpen` - a callback function, that will be called before zoom-in.
+    - `onBeforeClose` - a callback function, that will be called before zoom-out.
 ## License
 
 MIT

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                     bgOpacity: .85,
                     onOpen: openCallback,
                     onClose: closeCallback
+                    onBeforeOpen: beforeOpenCallback,
                 })
                 .listen('.zoom')
 
@@ -89,6 +90,11 @@
             function closeCallback (el) {
                 console.log('zoomed out on: ')
                 console.log(el)
+            }
+
+            function beforeOpenCallback (el) {
+            	console.log('on before zoomed in on:')
+            	console.log(el)
             }
         </script>
     </body>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
             	console.log(el)
             }
 
-			function beforeCloseCallback (el) {
+            function beforeCloseCallback (el) {
             	console.log('on before zoomed out on:')
             	console.log(el)
             }

--- a/index.html
+++ b/index.html
@@ -77,8 +77,9 @@
                     bgColor: '#000',
                     bgOpacity: .85,
                     onOpen: openCallback,
-                    onClose: closeCallback
+                    onClose: closeCallback,
                     onBeforeOpen: beforeOpenCallback,
+                    onBeforeClose: beforeCloseCallback
                 })
                 .listen('.zoom')
 
@@ -96,6 +97,12 @@
             	console.log('on before zoomed in on:')
             	console.log(el)
             }
+
+			function beforeCloseCallback (el) {
+            	console.log('on before zoomed out on:')
+            	console.log(el)
+            }
+
         </script>
     </body>
 </html>

--- a/zoomerang.js
+++ b/zoomerang.js
@@ -29,6 +29,7 @@
         maxHeight: 300,
         onOpen: null,
         onClose: null,
+        onBeforeClose: null,
         onBeforeOpen: null
     }
 
@@ -243,6 +244,9 @@
 
             if (!shown || lock) return
             lock = true
+
+            // onBeforeClose event
+            if (options.onBeforeClose) options.onBeforeClose(target)
 
             var p  = placeholder.getBoundingClientRect(),
                 dx = p.left - (window.innerWidth - p.width) / 2,

--- a/zoomerang.js
+++ b/zoomerang.js
@@ -28,7 +28,8 @@
         maxWidth: 300,
         maxHeight: 300,
         onOpen: null,
-        onClose: null
+        onClose: null,
+        onBeforeOpen: null
     }
 
     // compatibility stuff
@@ -166,6 +167,9 @@
             target = typeof el === 'string'
                 ? document.querySelector(el)
                 : el
+
+            // onBeforeOpen event
+            if (options.onBeforeOpen) options.onBeforeOpen(target)
 
             shown = true
             lock = true


### PR DESCRIPTION
I added possibility to specify callback function for `onBeforeOpen` and `onBeforeClose` events, which are triggered before zoom-in and zoom-out resp. 

It is useful, when you need to make something with target: specify classname, add some extra transition effects, etc.