### PR TITLE
Add zoom cursors

### DIFF
--- a/zoomerang.js
+++ b/zoomerang.js
@@ -4,17 +4,8 @@
 
 (function () {
 
-    // Prefix helper
-    var prefix = (function () {
-        var styles = window.getComputedStyle(document.documentElement, ''),
-            pre = (Array.prototype.slice
-                .call(styles)
-                .join('')
-                .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
-            )[1];
-
-        return '-' + pre + '-';
-    })();
+    // webkit prefix helper
+    var prefix = 'WebkitAppearance' in document.documentElement.style ? '-webkit-' : ''
 
     // regex
     var percentageRE = /^([\d\.]+)%$/

--- a/zoomerang.js
+++ b/zoomerang.js
@@ -4,6 +4,18 @@
 
 (function () {
 
+    // Prefix helper
+    var prefix = (function () {
+        var styles = window.getComputedStyle(document.documentElement, ''),
+            pre = (Array.prototype.slice
+                .call(styles)
+                .join('')
+                .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
+            )[1];
+
+        return '-' + pre + '-';
+    })();
+
     // regex
     var percentageRE = /^([\d\.]+)%$/
 
@@ -48,6 +60,7 @@
         bottom: 0,
         opacity: 0,
         backgroundColor: options.bgColor,
+        cursor: prefix + 'zoom-out',
         transition: 'opacity ' +
             options.transitionDuration + ' ' +
             options.transitionTimingFunction
@@ -187,6 +200,7 @@
                 whiteSpace: 'nowrap',
                 marginTop: -p.height / 2 + 'px',
                 marginLeft: -p.width / 2 + 'px',
+                cursor: prefix + 'zoom-out',
                 transform: 'translate(' + dx + 'px, ' + dy + 'px)',
                 transition: ''
             }, true)
@@ -229,8 +243,6 @@
                 cb = cb || options.onOpen
                 if (cb) cb(target)
             })
-
-            
 
             return this
         },
@@ -279,6 +291,10 @@
                 }
                 return
             }
+
+            setStyle(el, {
+                cursor: prefix + 'zoom-in'
+            })
 
             el.addEventListener('click', function (e) {
                 e.stopPropagation()


### PR DESCRIPTION
This pull request relates to #17.

When hovering over a 'zoomerang'-element you will now be able to see a `zoom-in` cursor. When zoomerang is open, you'll get to see a `zoom-out` cursor on the overlay and the 'zoomerang'-element.