### PR TITLE
add escape event handler to call the close api

### DIFF
--- a/zoomerang.js
+++ b/zoomerang.js
@@ -315,6 +315,9 @@
 
     overlay.addEventListener('click', api.close)
     wrapper.addEventListener('click', api.close)
+    window.addEventListener('keydown', function(e) {
+        if (e.keyCode === 27)   api.close()
+    })
 
     // umd expose
     if (typeof exports == "object") {


### PR DESCRIPTION
Hi Evan,

I think it's an expected behavior that when you press "escape", the zoom layer should disappear, so I added these code.

What's your opinion?